### PR TITLE
Fix building for older OpenCV vesions

### DIFF
--- a/charuco_calibration/src/calibrate_camera_ros.cpp
+++ b/charuco_calibration/src/calibrate_camera_ros.cpp
@@ -98,7 +98,7 @@ static bool readDetectorParameters(string filename, Ptr<aruco::DetectorParameter
     fs["minCornerDistanceRate"] >> params->minCornerDistanceRate;
     fs["minDistanceToBorder"] >> params->minDistanceToBorder;
     fs["minMarkerDistanceRate"] >> params->minMarkerDistanceRate;
-#if (CV_VERSION_MAJOR == 3) && (CV_VERSION_MIDOR >= 3)
+#if (CV_VERSION_MAJOR == 3) && (CV_VERSION_MINOR >= 3)
     fs["cornerRefinementMethod"] >> params->cornerRefinementMethod;
 #endif
     fs["cornerRefinementWinSize"] >> params->cornerRefinementWinSize;

--- a/charuco_calibration/src/calibrate_camera_ros.cpp
+++ b/charuco_calibration/src/calibrate_camera_ros.cpp
@@ -98,7 +98,9 @@ static bool readDetectorParameters(string filename, Ptr<aruco::DetectorParameter
     fs["minCornerDistanceRate"] >> params->minCornerDistanceRate;
     fs["minDistanceToBorder"] >> params->minDistanceToBorder;
     fs["minMarkerDistanceRate"] >> params->minMarkerDistanceRate;
+#if (CV_VERSION_MAJOR == 3) && (CV_VERSION_MIDOR >= 3)
     fs["cornerRefinementMethod"] >> params->cornerRefinementMethod;
+#endif
     fs["cornerRefinementWinSize"] >> params->cornerRefinementWinSize;
     fs["cornerRefinementMaxIterations"] >> params->cornerRefinementMaxIterations;
     fs["cornerRefinementMinAccuracy"] >> params->cornerRefinementMinAccuracy;


### PR DESCRIPTION
`cornerRefinementMethod` is not a member of `DetectorParams` in OpenCV <= 3.2. Since OpenCV 3.2 is the default for ROS Melodic, this makes building somewhat complicated.

This P/R addresses that.